### PR TITLE
Feature/referral gas send

### DIFF
--- a/contracts/ClaimableSplitCoin.sol
+++ b/contracts/ClaimableSplitCoin.sol
@@ -25,7 +25,7 @@ contract ClaimableSplitCoin is SplitCoin {
       for(uint depositIndex = lastClaimIndex; depositIndex < deposits.length; depositIndex++) {
         uint value = deposits[depositIndex] * splits[splitIndex].ppm / 1000000.00;
         lastUserClaim[user] = depositIndex + 1;
-        splits[splitIndex].to.call.gas(50000)(value);
+        require(splits[splitIndex].to.call.gas(60000).value(value)());
         SplitTransfer(splits[splitIndex].to, value, this.balance);
       }
     }

--- a/contracts/ClaimableSplitCoin.sol
+++ b/contracts/ClaimableSplitCoin.sol
@@ -25,7 +25,7 @@ contract ClaimableSplitCoin is SplitCoin {
       for(uint depositIndex = lastClaimIndex; depositIndex < deposits.length; depositIndex++) {
         uint value = deposits[depositIndex] * splits[splitIndex].ppm / 1000000.00;
         lastUserClaim[user] = depositIndex + 1;
-        splits[splitIndex].to.transfer(value);
+        splits[splitIndex].to.call.gas(50000)(value);
         SplitTransfer(splits[splitIndex].to, value, this.balance);
       }
     }

--- a/contracts/SplitCoin.sol
+++ b/contracts/SplitCoin.sol
@@ -55,7 +55,7 @@ contract SplitCoin {
   function pay () public payable {
     for(uint index = 0; index < splits.length; index++) {
       uint value = (msg.value) * splits[index].ppm / 1000000.00;
-      splits[index].to.transfer(value);
+      splits[index].to.call.gas(50000)(value);
       SplitTransfer(splits[index].to, value, this.balance);
     }
   }

--- a/contracts/SplitCoin.sol
+++ b/contracts/SplitCoin.sol
@@ -55,7 +55,7 @@ contract SplitCoin {
   function pay () public payable {
     for(uint index = 0; index < splits.length; index++) {
       uint value = (msg.value) * splits[index].ppm / 1000000.00;
-      splits[index].to.call.gas(50000)(value);
+      require(splits[index].to.call.gas(60000).value(value)());
       SplitTransfer(splits[index].to, value, this.balance);
     }
   }

--- a/contracts/SplitCoinFactory.sol
+++ b/contracts/SplitCoinFactory.sol
@@ -3,14 +3,37 @@ import "./ClaimableSplitCoin.sol";
 
 contract SplitCoinFactory {
   mapping(address => address[]) public contracts;
+  mapping(address => uint) public referralContracts;
   event Deployed (
     address _deployed
   );
+
   function make(address[] users, uint[] ppms, address refer, bool claimable) public returns (address) {
     address sc = 0x0;
-    sc = new ClaimableSplitCoin(users, ppms, refer, claimable);
+    address referContract = 0x0;
+    if(refer != 0x0 && contracts[refer].length > 0) {
+      uint referContractIndex = referralContracts[refer] - 1;
+      if(referContractIndex >= 0) {
+        referContract = contracts[refer][referContractIndex];
+      }
+    }
+    sc = new ClaimableSplitCoin(users, ppms, referContract, claimable);
     contracts[msg.sender].push(sc);
     Deployed(sc);
     return sc;
+  }
+
+  function generateReferralAddress() public returns (address) {
+    uint[] memory ppms = new uint[](1);
+    address[] memory users = new address[](1);
+    ppms[0] = 1000000;
+    users[0] = msg.sender;
+
+    address referralContract = make(users, ppms, 0x0, true);
+    if(referralContract != 0x0) {
+      uint index = contracts[msg.sender].length;
+      referralContracts[msg.sender] = index;
+    }
+    return referralContract;
   }
 }

--- a/contracts/SplitCoinFactory.sol
+++ b/contracts/SplitCoinFactory.sol
@@ -5,9 +5,12 @@ contract SplitCoinFactory {
   mapping(address => address[]) public contracts;
   mapping(address => uint) public referralContracts;
   mapping(address => address) public referredBy;
+  mapping(address => address[]) public referrals;
+  address[] public deployed;
   event Deployed (
     address _deployed
   );
+
 
   function make(address[] users, uint[] ppms, address refer, bool claimable) public returns (address) {
     address referContract = referredBy[msg.sender];
@@ -16,10 +19,12 @@ contract SplitCoinFactory {
       if(referContractIndex >= 0) {
         referContract = contracts[refer][referContractIndex];
         referredBy[msg.sender] = referContract;
+        referrals[refer].push(msg.sender);
       }
     }
     address sc = new ClaimableSplitCoin(users, ppms, referContract, claimable);
     contracts[msg.sender].push(sc);
+    deployed.push(sc);
     Deployed(sc);
     return sc;
   }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -6,6 +6,6 @@ module.exports = function(deployer) {
    *const MILLION = 1000000;
    *let half = MILLION / 2;
 	 */
-	deployer.deploy(SplitCoinFactory, {gas: '0x2DC6C0', gasPrice: '0x4A817C800'});
+	deployer.deploy(SplitCoinFactory, {gas: '0x2DC6C0', gasPrice: '0x3B9ACA00'});
   //deployer.deploy(SplitCoin, [accounts[0], accounts[1]], [half, half], "0x0");
 };

--- a/test/splitcoin.factory.test.js
+++ b/test/splitcoin.factory.test.js
@@ -52,7 +52,7 @@ contract('SplitCoinFactory', (accounts) => {
     return SplitCoinFactory.deployed()
       .then((splitFactory) => {
         factory = splitFactory;
-        return factory.generateReferralAddress();
+        return factory.generateReferralAddress('0x0');
       })
       .then((tx) => {
         return factory.referralContracts(accounts[0]);

--- a/test/splitcoin.factory.test.js
+++ b/test/splitcoin.factory.test.js
@@ -45,4 +45,38 @@ contract('SplitCoinFactory', (accounts) => {
         }
       });
   });
+
+
+  it("Should be able to generate a referal address", () => {
+    let factory = null;
+    return SplitCoinFactory.deployed()
+      .then((splitFactory) => {
+        factory = splitFactory;
+        return factory.generateReferralAddress();
+      })
+      .then((tx) => {
+        return factory.referralContracts(accounts[0]);
+      })
+      .then(async(index) => {
+        let indexNum = index.toFixed();
+        let splitCoinAddr = await factory.contracts(accounts[0], indexNum - 1);
+        return web3.eth.contract(splitcoinJson.abi).at(splitCoinAddr);
+      })
+      .then(async (splitCoin) => {
+        assert.equal(splitCoin != null, true, "The splitCoin should be defined");
+        return splitCoin.splits(1);
+      })
+      .then((split) => {
+        let splitData = {
+          to: '',
+          ppm: 0
+        };
+        splitData.to = split[0];
+        splitData.ppm = split[1].toFixed();
+        assert.equal(split != null, true, "There should be a split at index 1");
+        assert.equal(splitData.to, accounts[0], "The contract should have the user at index 1");
+        assert.equal(splitData.ppm < 1000000, true, "The user should get less than the whole amount (dev_fee)");
+        assert.equal(splitData.ppm > 900000, true, "The user should get more than 90%");
+      });
+  });
 });

--- a/truffle.js
+++ b/truffle.js
@@ -11,14 +11,12 @@ module.exports = {
       port: 8545,
       network_id: "1",
       gas: 3000000,
-      gasPrice: 1000000000
     },
     srvmain: {
       host: "192.168.0.12",
       port: 8545,
       network_id: "1",
       gas: 3000000,
-      gasPrice: 1000000000
     },
     ropsten: {
       host: "localhost",

--- a/truffle.js
+++ b/truffle.js
@@ -7,12 +7,26 @@ module.exports = {
       gas: 3000000,
     },
     main: {
+      host: "localhost",
+      port: 8545,
+      network_id: "1",
+      gas: 3000000,
+      gasPrice: 1000000000
+    },
+    srvmain: {
       host: "192.168.0.12",
       port: 8545,
       network_id: "1",
       gas: 3000000,
+      gasPrice: 1000000000
     },
     ropsten: {
+      host: "localhost",
+      port: 8546,
+      network_id: "3",
+      gas: 3000000,
+    },
+    srvropsten: {
       host: "192.168.0.12",
       port: 8546,
       network_id: "3",


### PR DESCRIPTION
# Added referral mechanism. 
As for now this mechanism only marks you as the referrer for the one contract. In the future this should be for all future contracts made by the referred user. Perhaps I'll do this before I merge this in.

# Split to Splits
Now split contracts are able to send to  claimable split contracts, and other contracts that consume 60k gas or less. This probably creates a re-entrancy bug on the non-claimable contracts, but I'm not sure how disruptive that would be yet. Need to test it. 